### PR TITLE
fixing build error

### DIFF
--- a/src/plugins/ids.js
+++ b/src/plugins/ids.js
@@ -56,7 +56,7 @@ Plugin.prototype = {
           }
         });
 
-        file.contents = new Buffer(file.$el.root().html());    
+        file.contents = new Buffer(file.$el.root().html());
 
         cb(null, file);
       })

--- a/src/plugins/ids.js
+++ b/src/plugins/ids.js
@@ -56,7 +56,7 @@ Plugin.prototype = {
           }
         });
 
-        file.contents = new Buffer(file.$el("body").html());
+        file.contents = new Buffer(file.$el.root().html());    
 
         cb(null, file);
       })

--- a/src/plugins/images.js
+++ b/src/plugins/images.js
@@ -62,7 +62,7 @@ function replaceSrc(imageMap) {
 
     // only if we find an image, replace contents in file
     if (changed) {
-      file.contents = new Buffer(file.$el("body").html());
+      file.contents = new Buffer(file.$el.root().html());
     }
 
     cb(null, file);


### PR DESCRIPTION
I have been getting build error where `file.$el("body").html();` returns `null` with more recent versions of node. This change suggested by @meiamsome works. I'm not sure if this should be merged (?), will it break magic book for others? Noting it here nonetheless.