### PR TITLE
Fix broken build process - updated through2 dep to v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "slug": "^0.9.1",
     "stream-exhaust": "^1.0.1",
     "streamqueue": "^1.1.1",
-    "through2": "^2.0.1",
+    "through2": "3.0.1",
     "tinyliquid": "^0.2.31",
     "vinyl-fs": "^2.4.2",
     "yaml-front-matter": "^3.4.0",


### PR DESCRIPTION
Hi!

## What change does this produce
- Fix broken build process - updated `through2` dep to `v3.0.1`

## Does this cause any breaking changes
- No

## Any other notes
- Make sure to merge in the following PRs associated with the `magicbook-katex` and `magicbook-codesplit` which are also using an old version of `through2` (in progress)

cc/ @shiffman