### PR TITLE
Bump dep versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "magicbook",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,9 +305,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
     },
     "clean-css": {
       "version": "4.2.1",
@@ -1748,9 +1748,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -1991,9 +1991,9 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         },
         "yallist": {
           "version": "3.0.3",
@@ -2390,9 +2390,9 @@
       }
     },
     "prince": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/prince/-/prince-1.6.2.tgz",
-      "integrity": "sha512-MipEV389DN3SNcsB179XqJd6GvDoPR51k5ep9ucdVT/MeEs1wLlmhqa3Ffw8aTNtNaMUsOPmNG9aNg6NFNS8ug==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/prince/-/prince-1.6.3.tgz",
+      "integrity": "sha512-CnAO0Z/VDf1Lhqb0iA21Dc2EfJzR4vkmGmeDT7pzjM8uwEr5uANlrPnrSgrV8GgFZorq3urwBF4vioL07j/v3A==",
       "requires": {
         "chalk": "2.4.2",
         "lodash": "4.17.11",
@@ -2401,7 +2401,7 @@
         "promise": "8.0.3",
         "request": "2.88.0",
         "rimraf": "2.6.3",
-        "tar": "4.4.8",
+        "tar": "4.4.10",
         "which": "1.3.1"
       },
       "dependencies": {
@@ -2423,10 +2423,15 @@
             "supports-color": "^5.3.0"
           }
         },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
         "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         },
         "supports-color": {
           "version": "5.5.0",
@@ -2437,17 +2442,17 @@
           }
         },
         "tar": {
-          "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "version": "4.4.10",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+          "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.3.5",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/magicbookproject/magicbook.git",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "name": "magicbook",
   "description": "The magic book project is an open source framework for creating digital and print books",
   "author": "magicbookproject",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp-uglify": "^3.0.2",
     "gulp-util": "^3.0.8",
     "hashids": "^1.2.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "markdown-it": "^8.4.2",
     "mkdirp": "^0.5.1",
     "modify-filename": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^0.5.1",
     "modify-filename": "^1.1.0",
     "node-sass": "^4.12.0",
-    "prince": "^1.6.2",
+    "prince": "^1.6.3",
     "rev-hash": "^3.0.0",
     "rev-path": "^2.0.0",
     "slug": "^1.1.0",


### PR DESCRIPTION
Bumps the dependencies:
* lodash to 4.17.15 // addresses https://github.com/nature-of-code/noc-book-2/pull/56 
* prince to 1.6.3

Bumps the magicbook version to 0.1.19 for release on npm to stay current.

cc: @shiffman - I will bump the versions for lodash on `magicbook-codesplit` and `magicbook-katex` and then make a release on npm for the magicbook and magicbook plugins.