### PR TITLE
fixes #29; img.src attribute not correctly resolved on Windows

### DIFF
--- a/src/plugins/images.js
+++ b/src/plugins/images.js
@@ -44,7 +44,10 @@ function replaceSrc(imageMap) {
 
       //make sure to convert the src attribute to the specific OS format, so they are correctly matched in the imageMap
       //e.g. on windows slashes are converted to backslashes like for instance images/fig01.png -> images\fig01.png
-      src = src ? path.normalize(src) : src;
+      if (src && !src.match(/^http/)) {
+        src = path.normalize(src)
+      }
+
 
       // if this image exists in source folder,
       // replace src with new source

--- a/src/plugins/images.js
+++ b/src/plugins/images.js
@@ -42,6 +42,10 @@ function replaceSrc(imageMap) {
       var jel = file.$el(this);
       var src = jel.attr("src");
 
+      //make sure to convert the src attribute to the specific OS format, so they are correctly matched in the imageMap
+      //e.g. on windows slashes are converted to backslashes like for instance images/fig01.png -> images\fig01.png
+      src = src ? path.normalize(src) : src;
+
       // if this image exists in source folder,
       // replace src with new source
       if (imageMap[src]) {


### PR DESCRIPTION
solves [image files are not found on Windows · Issue #29 ](https://github.com/magicbookproject/magicbook/issues/29)